### PR TITLE
google plus dead

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -239,7 +239,6 @@ Facebook: <https://www.facebook.com/CreativeTim>
 
 Dribbble: <https://dribbble.com/creativetim>
 
-Google+: <https://plus.google.com/+CreativetimPage>
 
 Instagram: <https://www.instagram.com/CreativeTimOfficial>
 


### PR DESCRIPTION
Google plus is dead - those links can be removed because they also don't work.